### PR TITLE
branch_worker: Check pr.user.login for relevant pr

### DIFF
--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -876,11 +876,13 @@ class BranchWorker(GithubConnector):
         """
         src_user = none_throws(pr.head.user).login
         tgt_user = none_throws(pr.base.user).login
+        pr_user = none_throws(pr.user).login
         tgt_branch = pr.base.ref
         state = pr.state
         if (
             src_user == self.user_or_org
             and tgt_user == self.user_or_org
+            and pr_user == self.user_login
             and tgt_branch == self.repo_pr_base_branch
             and state == "open"
         ):

--- a/tests/test_branch_worker.py
+++ b/tests/test_branch_worker.py
@@ -324,8 +324,10 @@ class TestBranchWorker(unittest.IsolatedAsyncioTestCase):
 
         # Set our user login name
         self._bw.user_or_org = user_login
+        self._bw.user_login = user_login
 
         def make_munch(
+            user: str = user_login,
             head_user: str = user_login,
             base_user: str = user_login,
             base_ref: str = TEST_REPO_PR_BASE_BRANCH,
@@ -334,6 +336,7 @@ class TestBranchWorker(unittest.IsolatedAsyncioTestCase):
             """Helper to make a Munch that can be consumed as a PR (e.g accessing nested attributes)"""
             return munchify(
                 {
+                    "user": {"login": user},
                     "head": {"user": {"login": head_user}},
                     "base": {"user": {"login": base_user}, "ref": base_ref},
                     "state": state,
@@ -351,6 +354,11 @@ class TestBranchWorker(unittest.IsolatedAsyncioTestCase):
                 name="Relevant PR",
                 pr=make_munch(),
                 relevant=True,
+            ),
+            TestCase(
+                name="Wrong user",
+                pr=make_munch(user="bar"),
+                relevant=False,
             ),
             TestCase(
                 name="Wrong head user",


### PR DESCRIPTION
When a PR is created from a different branch (instead of a fork), we see pr['head']'user']['login'] and pr['base']['user']['login'] are both "kernel-patches", but pr['user']['login'] is different. Such PR should not be considered as relevant. Add a check to cover this case.