### PR TITLE
README: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ python -m venv .venv
 poetry install
 
 # Test
-poetry run python -m unittests
+poetry run python -m unittest
 ```
 
 ## Running


### PR DESCRIPTION
Fix typo in the command to run unit test: s/unittests/unittest/.