### PR TITLE
Fix open source unit tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
+import importlib.resources
 import logging
 
 logging.disable()
+
+
+def read_fixture(filepath: str) -> str:
+    return (
+        importlib.resources.files(__package__)
+        .joinpath("fixtures")
+        .joinpath(filepath)
+        .read_text()
+    )

--- a/tests/test_branch_worker.py
+++ b/tests/test_branch_worker.py
@@ -6,8 +6,6 @@
 
 # pyre-unsafe
 
-import importlib.resources
-import os
 import random
 import re
 import shutil
@@ -50,6 +48,8 @@ from tests.common.patchwork_mock import (
     get_default_pw_client,
     init_pw_responses,
 )
+
+from . import read_fixture
 
 
 TEST_REPO = "repo"
@@ -102,12 +102,6 @@ SERIES_DATA: Dict[str, Any] = {
     "submitter": {"email": "a-user@example.com"},
     "mbox": "https://example.com",
 }
-
-
-def read_fixture(filepath: str) -> str:
-    with importlib.resources.path(__package__, "fixtures") as base:
-        with open(os.path.join(base, "fixtures", filepath)) as f:
-            return f.read()
 
 
 class BranchWorkerMock(BranchWorker):

--- a/tests/test_github_logs.py
+++ b/tests/test_github_logs.py
@@ -6,8 +6,6 @@
 
 # pyre-unsafe
 
-import importlib.resources
-import os
 import unittest
 
 from aioresponses import aioresponses
@@ -15,11 +13,7 @@ from github.WorkflowJob import WorkflowJob
 
 from kernel_patches_daemon.github_logs import BpfGithubLogExtractor, GithubFailedJobLog
 
-
-def read_fixture(filepath: str) -> str:
-    with importlib.resources.path(__package__, "fixtures") as base:
-        with open(os.path.join(base, "fixtures", filepath)) as f:
-            return f.read()
+from . import read_fixture
 
 
 class MockWorkflowJob(WorkflowJob):


### PR DESCRIPTION
Summary: We were adding an extra "fixtures" directory for fixture paths in TARGETS. Pathing doesn't work like that for standard python imports, so remove this extra level. Also consolidate the two read_fixture() definitions into a single place

Differential Revision: D58969097
