### PR TITLE
test: Make tests compatible with yarl 1.9.5+

### DIFF
--- a/tests/common/patchwork_mock.py
+++ b/tests/common/patchwork_mock.py
@@ -30,13 +30,13 @@ class PatchworkMock(Patchwork):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         # Force patchwork to use loopback/port 0 for whatever network access
         # we fail to mock
-        # kwargs["server"] = "https://127.0.0.1:0"
+        # kwargs["server"] = "https://127.0.0.1"
         super().__init__(*args, **kwargs)
 
 
 def get_default_pw_client() -> PatchworkMock:
     return PatchworkMock(
-        server="127.0.0.1:0",
+        server="127.0.0.1",
         api_version="1.1",
         search_patterns=[{"archived": False, "project": PROJECT, "delegate": DELEGATE}],
         auth_token="mocktoken",
@@ -83,7 +83,7 @@ FOO_SERIES_LAST = 10
 
 DEFAULT_FREEZE_DATE = "2010-07-23T00:00:00"
 DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
-    "https://127.0.0.1:0/api/1.1/series/?q=foo": [
+    "https://127.0.0.1/api/1.1/series/?q=foo": [
         # Does not match the subject name
         {
             "id": 1,
@@ -170,7 +170,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         },
     ],
     # Multiple relevant series to test our guess_pr logic.
-    "https://127.0.0.1:0/api/1.1/series/?q=barv2": [
+    "https://127.0.0.1/api/1.1/series/?q=barv2": [
         # Matches and has relevant diff.
         {
             "id": 6,
@@ -197,7 +197,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         },
     ],
     # Single relevant series to test our guess_pr logic.
-    "https://127.0.0.1:0/api/1.1/series/?q=code": [
+    "https://127.0.0.1/api/1.1/series/?q=code": [
         # Matches, has one relevant diffs, and is the most recent series.
         {
             "id": 9,
@@ -213,42 +213,42 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         },
     ],
     # Correct project and delegate
-    "https://127.0.0.1:0/api/1.1/patches/11/": {
+    "https://127.0.0.1/api/1.1/patches/11/": {
         "id": 11,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
         "archived": False,
     },
     # wrong project
-    "https://127.0.0.1:0/api/1.1/patches/12/": {
+    "https://127.0.0.1/api/1.1/patches/12/": {
         "id": 12,
         "project": {"id": PROJECT + 1},
         "delegate": {"id": DELEGATE},
         "archived": False,
     },
     # Wrong delegate
-    "https://127.0.0.1:0/api/1.1/patches/13/": {
+    "https://127.0.0.1/api/1.1/patches/13/": {
         "id": 13,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE + 1},
         "archived": False,
     },
     # Correct project/delegate but archived
-    "https://127.0.0.1:0/api/1.1/patches/14/": {
+    "https://127.0.0.1/api/1.1/patches/14/": {
         "id": 14,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
         "archived": True,
     },
     # None project
-    "https://127.0.0.1:0/api/1.1/patches/15/": {
+    "https://127.0.0.1/api/1.1/patches/15/": {
         "id": 15,
         "project": None,
         "delegate": {"id": DELEGATE},
         "archived": False,
     },
     # None delegate
-    "https://127.0.0.1:0/api/1.1/patches/16/": {
+    "https://127.0.0.1/api/1.1/patches/16/": {
         "id": 16,
         "project": {"id": PROJECT},
         "delegate": None,
@@ -258,7 +258,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
     # Series test cases #
     #####################
     # An open series, is a series that has no patch in irrelevant state.
-    "https://127.0.0.1:0/api/1.1/series/665/": {
+    "https://127.0.0.1/api/1.1/series/665/": {
         "id": 665,
         "name": "[a/b] this series is *NOT* closed!",
         "date": "2010-07-20T01:00:00",
@@ -271,7 +271,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "mbox": "https://example.com",
     },
     # Patch in an relevant state.
-    "https://127.0.0.1:0/api/1.1/patches/6651/": {
+    "https://127.0.0.1/api/1.1/patches/6651/": {
         "id": 6651,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -281,7 +281,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "name": "foo",
     },
     # Patch in a relevant state.
-    "https://127.0.0.1:0/api/1.1/patches/6652/": {
+    "https://127.0.0.1/api/1.1/patches/6652/": {
         "id": 6652,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -293,7 +293,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "name": "[0/5, 1/2 , v42, V24, first patch tag, second patch tag, patch , some stuff with spaces , patch] bar",
     },
     # Patch in an relevant state.
-    "https://127.0.0.1:0/api/1.1/patches/6653/": {
+    "https://127.0.0.1/api/1.1/patches/6653/": {
         "id": 6653,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -303,7 +303,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "name": "[duplicate tag] foo",
     },
     # A closed series, is a series that has at least 1 patch in an irrelevant state.
-    "https://127.0.0.1:0/api/1.1/series/666/": {
+    "https://127.0.0.1/api/1.1/series/666/": {
         "id": 666,
         "name": "this series is closed!",
         "date": "2010-07-20T01:00:00",
@@ -315,7 +315,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "mbox": "https://example.com",
     },
     # Patch in an irrelevant state.
-    "https://127.0.0.1:0/api/1.1/patches/6661/": {
+    "https://127.0.0.1/api/1.1/patches/6661/": {
         "id": 6661,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -323,7 +323,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "state": get_dict_key(IRRELEVANT_STATES),
     },
     # Patch in a relevant state.
-    "https://127.0.0.1:0/api/1.1/patches/6662/": {
+    "https://127.0.0.1/api/1.1/patches/6662/": {
         "id": 6662,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -331,7 +331,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "state": get_dict_key(RELEVANT_STATES),
     },
     # Series with no cover letter and no patches.
-    "https://127.0.0.1:0/api/1.1/series/667/": {
+    "https://127.0.0.1/api/1.1/series/667/": {
         "id": 667,
         "name": "this series has no cover letter!",
         "date": "2010-07-20T01:00:00",
@@ -345,7 +345,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
     },
     # Expiration test cases
     # Series with expirable patches.
-    "https://127.0.0.1:0/api/1.1/series/668/": {
+    "https://127.0.0.1/api/1.1/series/668/": {
         "id": 668,
         "name": "this series has no cover letter!",
         "date": "2010-07-20T01:00:00",
@@ -358,7 +358,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "mbox": "https://example.com",
     },
     # Patch in a non-expirable state.
-    "https://127.0.0.1:0/api/1.1/patches/6681/": {
+    "https://127.0.0.1/api/1.1/patches/6681/": {
         "id": 6681,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -366,7 +366,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "state": "new",
     },
     # Patch in an expirable state.
-    "https://127.0.0.1:0/api/1.1/patches/6682/": {
+    "https://127.0.0.1/api/1.1/patches/6682/": {
         "id": 6682,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -375,7 +375,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "date": DEFAULT_FREEZE_DATE,
     },
     # Patch in a non-expirable state.
-    "https://127.0.0.1:0/api/1.1/patches/6683/": {
+    "https://127.0.0.1/api/1.1/patches/6683/": {
         "id": 6683,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -383,7 +383,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "state": "new",
     },
     # Series with no expirable patches.
-    "https://127.0.0.1:0/api/1.1/series/669/": {
+    "https://127.0.0.1/api/1.1/series/669/": {
         "id": 669,
         "name": "this series has no cover letter!",
         "date": "2010-07-20T01:00:00",
@@ -396,7 +396,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "mbox": "https://example.com",
     },
     # Patch in a non-expirable state.
-    "https://127.0.0.1:0/api/1.1/patches/6691/": {
+    "https://127.0.0.1/api/1.1/patches/6691/": {
         "id": 6691,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -404,7 +404,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "state": "new",
     },
     # Patch in a non-expirable state.
-    "https://127.0.0.1:0/api/1.1/patches/6692/": {
+    "https://127.0.0.1/api/1.1/patches/6692/": {
         "id": 6692,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},
@@ -412,7 +412,7 @@ DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
         "state": "new",
     },
     # Patch in a non-expirable state.
-    "https://127.0.0.1:0/api/1.1/patches/6693/": {
+    "https://127.0.0.1/api/1.1/patches/6693/": {
         "id": 6693,
         "project": {"id": PROJECT},
         "delegate": {"id": DELEGATE},

--- a/tests/test_branch_worker.py
+++ b/tests/test_branch_worker.py
@@ -53,13 +53,13 @@ from . import read_fixture
 
 
 TEST_REPO = "repo"
-TEST_REPO_URL = f"https://user:pass@127.0.0.1:0/org/{TEST_REPO}"
+TEST_REPO_URL = f"https://user:pass@127.0.0.1/org/{TEST_REPO}"
 TEST_REPO_BRANCH = "test_branch"
 TEST_REPO_PR_BASE_BRANCH = "test_branch_base"
 TEST_UPSTREAM_REPO_URL = "https://127.0.0.2:0/upstream_org/upstream_repo"
 TEST_UPSTREAM_BRANCH = "test_upstream_branch"
 TEST_CI_REPO = "ci-repo"
-TEST_CI_REPO_URL = f"https://user:pass@127.0.0.1:0/ci-org/{TEST_CI_REPO}"
+TEST_CI_REPO_URL = f"https://user:pass@127.0.0.1/ci-org/{TEST_CI_REPO}"
 TEST_CI_BRANCH = "test_ci_branch"
 TEST_BASE_DIRECTORY = "/repos"
 TEST_BRANCH = "test-branch"
@@ -917,7 +917,7 @@ class TestGitSeriesAlreadyApplied(unittest.IsolatedAsyncioTestCase):
         contains such commits.
         """
         data = {
-            "https://127.0.0.1:0/api/1.1/series/42/": {
+            "https://127.0.0.1/api/1.1/series/42/": {
                 "id": 42,
                 "name": "[a/b] this series is *NOT* closed!",
                 "date": "2010-07-20T01:00:00",
@@ -930,7 +930,7 @@ class TestGitSeriesAlreadyApplied(unittest.IsolatedAsyncioTestCase):
                 "mbox": "https://example.com",
             },
             **{
-                f"https://127.0.0.1:0/api/1.1/patches/{i}/": {
+                f"https://127.0.0.1/api/1.1/patches/{i}/": {
                     "id": i,
                     "project": {"id": "1234"},
                     "delegate": {"id": "12345"},

--- a/tests/test_github_connector.py
+++ b/tests/test_github_connector.py
@@ -42,7 +42,7 @@ DEFAULT_FREEZE_DATE = "2010-07-23T00:00:00"
 
 TEST_ORG = "org"
 TEST_REPO = "repo"
-TEST_REPO_URL = f"https://user:pass@127.0.0.1:0/{TEST_ORG}/{TEST_REPO}"
+TEST_REPO_URL = f"https://user:pass@127.0.0.1/{TEST_ORG}/{TEST_REPO}"
 TEST_APP_ID = 1
 TEST_INSTALLATION_ID = 2
 TEST_PRIV_KEY: str = (
@@ -372,10 +372,10 @@ class TestGithubConnectorAuth(unittest.TestCase):
             side_effect=side_effect,
         ) as p, freeze_time(DEFAULT_FREEZE_DATE):
             gc_app_auth = get_default_gc_app_auth_client(
-                repo_url=f"https://127.0.0.1:0/{TEST_ORG}/{TEST_REPO}"
+                repo_url=f"https://127.0.0.1/{TEST_ORG}/{TEST_REPO}"
             )
             self.assertEqual(
-                f"https://test_user[bot]:token1@127.0.0.1:0/{TEST_ORG}/{TEST_REPO}",
+                f"https://test_user[bot]:token1@127.0.0.1/{TEST_ORG}/{TEST_REPO}",
                 gc_app_auth.repo_url,
             )
             self.assertEqual(p.call_count, 1)
@@ -395,8 +395,8 @@ class TestGithubConnectorAuth(unittest.TestCase):
         test_cases = [
             TestCase(
                 name="port is 0",
-                initial_url=f"https://127.0.0.1:0/{TEST_ORG}/{TEST_REPO}",
-                expected_url=f"https://test_user[bot]:token1@127.0.0.1:0/{TEST_ORG}/{TEST_REPO}",
+                initial_url=f"https://127.0.0.1/{TEST_ORG}/{TEST_REPO}",
+                expected_url=f"https://test_user[bot]:token1@127.0.0.1/{TEST_ORG}/{TEST_REPO}",
             ),
             TestCase(
                 name="port is not 0",

--- a/tests/test_patchwork.py
+++ b/tests/test_patchwork.py
@@ -75,13 +75,13 @@ class TestPatchwork(PatchworkTestCase):
         self.assertEqual(json_resp["key1"], "value1")
 
     async def test_get_objects_recursive(self) -> None:
-        url = "https://127.0.0.1:0/api/1.1/projects/"
+        url = "https://127.0.0.1/api/1.1/projects/"
 
         @dataclass
         class Response:
             body: bytes
             headers: Dict[str, str]
-            url: str = "https://127.0.0.1:0/api/1.1/projects/"
+            url: str = "https://127.0.0.1/api/1.1/projects/"
             status_code: int = 200
 
         @dataclass
@@ -106,21 +106,21 @@ class TestPatchwork(PatchworkTestCase):
                         url=url,
                         body=b'["a"]',
                         headers={
-                            "Link": '<https://127.0.0.1:0/api/1.1/projects/?page=2>; rel="next"'
+                            "Link": '<https://127.0.0.1/api/1.1/projects/?page=2>; rel="next"'
                         },
                     ),
                     Response(
                         url=url + "?page=2",
                         body=b'["b"]',
                         headers={
-                            "Link": '<https://127.0.0.1:0/api/1.1/projects/?page=3>; rel="next", <https://127.0.0.1:0/api/1.1/projects/>; rel="prev"'
+                            "Link": '<https://127.0.0.1/api/1.1/projects/?page=3>; rel="next", <https://127.0.0.1/api/1.1/projects/>; rel="prev"'
                         },
                     ),
                     Response(
                         url=url + "?page=3",
                         body=b'["c"]',
                         headers={
-                            "Link": '<https://127.0.0.1:0/api/1.1/projects/?page=2>; rel="prev"'
+                            "Link": '<https://127.0.0.1/api/1.1/projects/?page=2>; rel="prev"'
                         },
                     ),
                 ],
@@ -181,13 +181,13 @@ class TestPatchwork(PatchworkTestCase):
         m.post(pattern, status=200)
         self._pw.auth_token = None
         await self._pw._Patchwork__try_post(
-            "https://127.0.0.1:0/some/random/url", "somerandomdata"
+            "https://127.0.0.1/some/random/url", "somerandomdata"
         )
         m.assert_not_called()
 
         self._pw.auth_token = ""
         await self._pw._Patchwork__try_post(
-            "https://127.0.0.1:0/some/random/url", "somerandomdata"
+            "https://127.0.0.1/some/random/url", "somerandomdata"
         )
         m.assert_not_called()
 
@@ -404,7 +404,7 @@ class TestSeries(PatchworkTestCase):
         CTX_URLENCODED = "vmtest+bpf-next-PR"
         EXPECTED_ID = 42
         contexts_responses = {
-            f"https://127.0.0.1:0/api/1.1/patches/12859379/checks/?context={CTX_URLENCODED}&order=-date&per_page=1": [
+            f"https://127.0.0.1/api/1.1/patches/12859379/checks/?context={CTX_URLENCODED}&order=-date&per_page=1": [
                 {
                     "context": CTX,
                     "date": "2010-01-02T00:00:00",
@@ -428,7 +428,7 @@ class TestSeries(PatchworkTestCase):
         contexts_responses.update(
             {
                 # Patch with existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
+                f"https://127.0.0.1/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
                     {
                         "context": DEFAULT_CHECK_CTX,
                         "date": "2010-01-01T00:00:00",
@@ -436,8 +436,8 @@ class TestSeries(PatchworkTestCase):
                     },
                 ],
                 # Patches without existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
-                f"https://127.0.0.1:0/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
             }
         )
 
@@ -450,7 +450,7 @@ class TestSeries(PatchworkTestCase):
         await series.set_check(
             context=DEFAULT_CHECK_CTX,
             status=Status.PENDING,
-            target_url="https://127.0.0.1:0/target",
+            target_url="https://127.0.0.1/target",
         )
         # Hack... aioresponses stores the requests that were made in a dictionary whose's key is a tuple,
         # of the form (method, url).
@@ -464,12 +464,12 @@ class TestSeries(PatchworkTestCase):
         """
         Test that we don't update checks if the state and target_url have not changed.
         """
-        TARGET_URL = "https://127.0.0.1:0/target"
+        TARGET_URL = "https://127.0.0.1/target"
         contexts_responses = copy.deepcopy(DEFAULT_TEST_RESPONSES)
         contexts_responses.update(
             {
                 # Patch with existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
+                f"https://127.0.0.1/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
                     {
                         "context": DEFAULT_CHECK_CTX,
                         "date": "2010-01-01T00:00:00",
@@ -478,8 +478,8 @@ class TestSeries(PatchworkTestCase):
                     },
                 ],
                 # Patches without existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
-                f"https://127.0.0.1:0/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
             }
         )
 
@@ -505,12 +505,12 @@ class TestSeries(PatchworkTestCase):
         """
         Test that we update checks if the state is the same, but target_url has changed.
         """
-        TARGET_URL = "https://127.0.0.1:0/target"
+        TARGET_URL = "https://127.0.0.1/target"
         contexts_responses = copy.deepcopy(DEFAULT_TEST_RESPONSES)
         contexts_responses.update(
             {
                 # Patch with existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
+                f"https://127.0.0.1/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
                     {
                         "context": DEFAULT_CHECK_CTX,
                         "date": "2010-01-01T00:00:00",
@@ -520,8 +520,8 @@ class TestSeries(PatchworkTestCase):
                     },
                 ],
                 # Patches without existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
-                f"https://127.0.0.1:0/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
             }
         )
 
@@ -546,12 +546,12 @@ class TestSeries(PatchworkTestCase):
         """
         Test that we update checks if the state is not the same, but target_url is.
         """
-        TARGET_URL = "https://127.0.0.1:0/target"
+        TARGET_URL = "https://127.0.0.1/target"
         contexts_responses = copy.deepcopy(DEFAULT_TEST_RESPONSES)
         contexts_responses.update(
             {
                 # Patch with existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
+                f"https://127.0.0.1/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
                     {
                         "context": DEFAULT_CHECK_CTX,
                         "date": "2010-01-01T00:00:00",
@@ -563,8 +563,8 @@ class TestSeries(PatchworkTestCase):
                     },
                 ],
                 # Patches without existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
-                f"https://127.0.0.1:0/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
             }
         )
 
@@ -590,12 +590,12 @@ class TestSeries(PatchworkTestCase):
         """
         Test that we do not update checks if the new state is pending and we have an existing final state.
         """
-        TARGET_URL = "https://127.0.0.1:0/target"
+        TARGET_URL = "https://127.0.0.1/target"
         contexts_responses = copy.deepcopy(DEFAULT_TEST_RESPONSES)
         contexts_responses.update(
             {
                 # Patch with existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
+                f"https://127.0.0.1/api/1.1/patches/6651/checks/{DEFAULT_CHECK_CTX_QUERY}": [
                     {
                         "context": DEFAULT_CHECK_CTX,
                         "date": "2010-01-01T00:00:00",
@@ -605,8 +605,8 @@ class TestSeries(PatchworkTestCase):
                     },
                 ],
                 # Patches without existing context
-                f"https://127.0.0.1:0/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
-                f"https://127.0.0.1:0/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6652/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
+                f"https://127.0.0.1/api/1.1/patches/6653/checks/{DEFAULT_CHECK_CTX_QUERY}": [],
             }
         )
 


### PR DESCRIPTION
With yarl 1.9.5 release, the tests would start failing.

Changelog: https://yarl.aio-libs.org/en/latest/changes/#id26

TL;DR, the :0 would get eaten and the mock would not intercept the http calls.

Tested this manually with 1.9.4 and 1.9.5.

The next diff which is part of #59 will confirm I did not screw up.