### PR TITLE
deps: update cryptography to ^43.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ python-dateutil = "^2.8.2"
 # Explicitly include cryptography package
 # It's required for PyJWT which is dependency of PyGithub
 # https://pyjwt.readthedocs.io/en/stable/installation.html#cryptographic-dependencies-optional
-cryptography = "^42.0.0"
+cryptography = "^43.0.1"
 certifi = "*"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Address depedabot alert: https://github.com/advisories/GHSA-h4gh-qq45-vh27
Signed-off-by: Manu Bretelle <chantr4@gmail.com>