### PR TITLE
email: update cc list to enable multiple recipients

### DIFF
--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -287,7 +287,7 @@ def build_email(
     ]
 
     to_list = copy.copy(config.smtp_to)
-    cc_list = copy.copy(config.smtp_cc)
+    cc_list = copy.copy(config.smtp_cc).split(",")
 
     if config.ignore_allowlist or email_in_submitter_allowlist(
         series.submitter_email, config.submitter_allowlist


### PR DESCRIPTION
Actually, I was getting an error with just one email.  Further below From my change on this LOC:

	for to in to_list + cc_list:

I was getting an error about concatenating a list and a string.  The to_list Was clearly a list based on how it was processed just above the for loop.

The cc_list printed its type as a list but it looked like a string logging it.

Either way, single or multiple entry cc in the config file, this patch works.