### PR TITLE
Revert codemod

### DIFF
--- a/kernel_patches_daemon/__main__.py
+++ b/kernel_patches_daemon/__main__.py
@@ -36,7 +36,7 @@ class ScriptMetricsExporter:
     def __init__(self, script: str) -> None:
         self.script = script
 
-    def export(self, project: str, metrics: dict) -> None:
+    def export(self, project: str, metrics: Dict) -> None:
         if os.path.isfile(self.script) and os.access(self.script, os.X_OK):
             p = Popen([self.script], stdout=PIPE, stdin=PIPE, stderr=PIPE)
             p.communicate(input=json.dumps(metrics).encode())

--- a/kernel_patches_daemon/branch_worker.py
+++ b/kernel_patches_daemon/branch_worker.py
@@ -28,7 +28,7 @@ from email.mime.text import MIMEText
 from enum import Enum
 from pathlib import Path
 from subprocess import PIPE
-from typing import Any, Final, IO
+from typing import Any, Dict, Final, IO, List, Optional, Tuple
 
 import dateutil.parser
 import git

--- a/kernel_patches_daemon/config.py
+++ b/kernel_patches_daemon/config.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
+from typing import Dict, List, Optional, Set
 
 
 logger = logging.getLogger(__name__)

--- a/kernel_patches_daemon/config.py
+++ b/kernel_patches_daemon/config.py
@@ -44,7 +44,7 @@ class GithubAppAuthConfig:
             ) from e
 
     @classmethod
-    def from_json(cls, json: dict) -> "GithubAppAuthConfig":
+    def from_json(cls, json: Dict) -> "GithubAppAuthConfig":
         private_key_config = json.keys() & {
             "private_key",
             "private_key_path",
@@ -78,12 +78,12 @@ class BranchConfig:
     upstream_branch: str
     ci_repo: str
     ci_branch: str
-    github_oauth_token: str | None
-    github_app_auth: GithubAppAuthConfig | None
+    github_oauth_token: Optional[str]
+    github_app_auth: Optional[GithubAppAuthConfig]
 
     @classmethod
-    def from_json(cls, json: dict) -> "BranchConfig":
-        github_app_auth_config: GithubAppAuthConfig | None = None
+    def from_json(cls, json: Dict) -> "BranchConfig":
+        github_app_auth_config: Optional[GithubAppAuthConfig] = None
         if app_auth_json := json.get("github_app_auth"):
             try:
                 github_app_auth_config = GithubAppAuthConfig.from_json(app_auth_json)
@@ -108,21 +108,21 @@ class EmailConfig:
     smtp_user: str
     smtp_from: str
     smtp_pass: str
-    smtp_to: list[str]
-    smtp_cc: list[str]
-    smtp_http_proxy: str | None
+    smtp_to: List[str]
+    smtp_cc: List[str]
+    smtp_http_proxy: Optional[str]
     # List of email addresses of patch submitters to whom we send email
     # notifications only for *their* very submission. This attribute is meant to
     # be temporary while the email notification feature is being rolled out.
     # Once we send email notifications to all patch submitters it can be
     # removed.
-    submitter_allowlist: list[re.Pattern]
+    submitter_allowlist: List[re.Pattern]
     # Ignore the `submitter_allowlist` entries and send emails to all patch
     # submitters, unconditionally.
     ignore_allowlist: bool
 
     @classmethod
-    def from_json(cls, json: dict) -> "EmailConfig":
+    def from_json(cls, json: Dict) -> "EmailConfig":
         return cls(
             smtp_host=json["host"],
             smtp_port=json.get("port", 465),
@@ -143,13 +143,13 @@ class EmailConfig:
 class PatchworksConfig:
     base_url: str
     project: str
-    search_patterns: list[dict]
+    search_patterns: List[Dict]
     lookback: int
-    user: str | None
-    token: str | None
+    user: Optional[str]
+    token: Optional[str]
 
     @classmethod
-    def from_json(cls, json: dict) -> "PatchworksConfig":
+    def from_json(cls, json: Dict) -> "PatchworksConfig":
         return cls(
             base_url=json["server"],
             project=json["project"],
@@ -164,13 +164,13 @@ class PatchworksConfig:
 class KPDConfig:
     version: int
     patchwork: PatchworksConfig
-    email: EmailConfig | None
-    branches: dict[str, BranchConfig]
-    tag_to_branch_mapping: dict[str, list[str]]
+    email: Optional[EmailConfig]
+    branches: Dict[str, BranchConfig]
+    tag_to_branch_mapping: Dict[str, List[str]]
     base_directory: str
 
     @classmethod
-    def from_json(cls, json: dict) -> "KPDConfig":
+    def from_json(cls, json: Dict) -> "KPDConfig":
         try:
             version = int(json["version"])
         except (KeyError, IndexError) as e:

--- a/kernel_patches_daemon/daemon.py
+++ b/kernel_patches_daemon/daemon.py
@@ -10,8 +10,7 @@ import asyncio
 import logging
 import signal
 import threading
-from collections.abc import Callable
-from typing import Dict, Final, Optional
+from typing import Callable, Dict, Final, Optional
 
 from kernel_patches_daemon.config import KPDConfig
 from kernel_patches_daemon.github_sync import GithubSync
@@ -33,8 +32,8 @@ class KernelPatchesWorker:
     def __init__(
         self,
         kpd_config: KPDConfig,
-        labels_cfg: dict[str, str],
-        metrics_logger: Callable | None = None,
+        labels_cfg: Dict[str, str],
+        metrics_logger: Optional[Callable] = None,
         loop_delay: int = DEFAULT_LOOP_DELAY,
         max_concurrent_restarts: int = DEFAULT_MAX_CONCURRENT_RESTARTS,
     ) -> None:
@@ -77,12 +76,12 @@ class KernelPatchesDaemon:
     def __init__(
         self,
         kpd_config: KPDConfig,
-        labels_cfg: dict[str, str],
-        metrics_logger: Callable | None = None,
+        labels_cfg: Dict[str, str],
+        metrics_logger: Optional[Callable] = None,
         max_concurrent_restarts: int = 1,
     ) -> None:
         self._stopping_lock = threading.Lock()
-        self._task: asyncio.Task | None = None
+        self._task: Optional[asyncio.Task] = None
         self.worker = KernelPatchesWorker(
             kpd_config=kpd_config,
             labels_cfg=labels_cfg,

--- a/kernel_patches_daemon/daemon.py
+++ b/kernel_patches_daemon/daemon.py
@@ -11,7 +11,7 @@ import logging
 import signal
 import threading
 from collections.abc import Callable
-from typing import Final
+from typing import Dict, Final, Optional
 
 from kernel_patches_daemon.config import KPDConfig
 from kernel_patches_daemon.github_sync import GithubSync

--- a/kernel_patches_daemon/github_connector.py
+++ b/kernel_patches_daemon/github_connector.py
@@ -10,6 +10,7 @@ import logging
 import os
 from datetime import timedelta
 from enum import Enum
+from typing import Optional
 from urllib.parse import urlparse
 
 from github import Auth, Github, GithubException, GithubIntegration

--- a/kernel_patches_daemon/github_connector.py
+++ b/kernel_patches_daemon/github_connector.py
@@ -61,9 +61,9 @@ class GithubConnector:
     def __init__(
         self,
         repo_url: str,
-        github_oauth_token: str | None = None,
-        app_auth: Auth.AppInstallationAuth | None = None,
-        http_retries: int | None = None,
+        github_oauth_token: Optional[str] = None,
+        app_auth: Optional[Auth.AppInstallationAuth] = None,
+        http_retries: Optional[int] = None,
     ) -> None:
 
         assert bool(github_oauth_token) ^ bool(

--- a/kernel_patches_daemon/github_logs.py
+++ b/kernel_patches_daemon/github_logs.py
@@ -11,8 +11,7 @@ import io
 import logging
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
-from typing import Final, List, Optional
+from typing import Final, List, Optional, Sequence
 
 import aiohttp
 from github.WorkflowJob import WorkflowJob
@@ -59,7 +58,7 @@ class GithubLogExtractor(ABC):
     @abstractmethod
     async def extract_failed_logs(
         self, jobs: Sequence[WorkflowJob]
-    ) -> list[GithubFailedJobLog]:
+    ) -> List[GithubFailedJobLog]:
         """
         Given a list of workflow jobs, `jobs`, filter out all the successful
         jobs. For the remaining failed jobs, pull out output logs. The logs
@@ -81,7 +80,7 @@ class GithubLogExtractor(ABC):
 class DefaultGithubLogExtractor(GithubLogExtractor):
     async def extract_failed_logs(
         self, jobs: Sequence[WorkflowJob]
-    ) -> list[GithubFailedJobLog]:
+    ) -> List[GithubFailedJobLog]:
         """Metadata parsing is tree-specific. So by default it's safer to do nothing."""
         return []
 
@@ -98,7 +97,7 @@ class BpfGithubLogExtractor(GithubLogExtractor):
 
     def __init__(self) -> None:
         # Needs to be initialized in async function
-        self._session: aiohttp.ClientSession | None = None
+        self._session: Optional[aiohttp.ClientSession] = None
 
     async def _get_session(self) -> aiohttp.ClientSession:
         """Return cached http session; creating if not already created"""
@@ -108,7 +107,7 @@ class BpfGithubLogExtractor(GithubLogExtractor):
 
         return self._session
 
-    async def _extract_job_log(self, job: WorkflowJob) -> GithubFailedJobLog | None:
+    async def _extract_job_log(self, job: WorkflowJob) -> Optional[GithubFailedJobLog]:
         status = gh_conclusion_to_status(job.conclusion)
         if status != Status.FAILURE:
             return None
@@ -148,7 +147,7 @@ class BpfGithubLogExtractor(GithubLogExtractor):
 
     async def extract_failed_logs(
         self, jobs: Sequence[WorkflowJob]
-    ) -> list[GithubFailedJobLog]:
+    ) -> List[GithubFailedJobLog]:
         tasks = [asyncio.create_task(self._extract_job_log(job)) for job in jobs]
         results = await asyncio.gather(*tasks)
         return [result for result in results if result is not None]

--- a/kernel_patches_daemon/github_logs.py
+++ b/kernel_patches_daemon/github_logs.py
@@ -12,7 +12,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Final
+from typing import Final, List, Optional
 
 import aiohttp
 from github.WorkflowJob import WorkflowJob

--- a/kernel_patches_daemon/github_sync.py
+++ b/kernel_patches_daemon/github_sync.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Sequence
-from typing import Final
+from typing import Dict, Final, List, Optional
 
 from github import Auth
 from github.PullRequest import PullRequest

--- a/kernel_patches_daemon/github_sync.py
+++ b/kernel_patches_daemon/github_sync.py
@@ -9,8 +9,7 @@
 import asyncio
 import logging
 import time
-from collections.abc import Sequence
-from typing import Dict, Final, List, Optional
+from typing import Dict, Final, List, Optional, Sequence
 
 from github import Auth
 from github.PullRequest import PullRequest
@@ -58,7 +57,7 @@ DEFAULT_HTTP_RETRIES: Final[int] = 3
 
 def github_app_auth_from_branch_config(
     branch_config: BranchConfig,
-) -> Auth.AppInstallationAuth | None:
+) -> Optional[Auth.AppInstallationAuth]:
     if app_auth_config := branch_config.github_app_auth:
         return Auth.AppInstallationAuth(
             Auth.AppAuth(
@@ -87,7 +86,7 @@ class GithubSync(Stats):
     def __init__(
         self,
         kpd_config: KPDConfig,
-        labels_cfg: dict[str, str],
+        labels_cfg: Dict[str, str],
         http_retries: int = DEFAULT_HTTP_RETRIES,
     ) -> None:
         self.pw = Patchwork(
@@ -98,7 +97,7 @@ class GithubSync(Stats):
             http_retries=http_retries,
         )
         self.tag_to_branch_mapping = kpd_config.tag_to_branch_mapping
-        self.workers: dict[str, BranchWorker] = {
+        self.workers: Dict[str, BranchWorker] = {
             branch: BranchWorker(
                 patchwork=self.pw,
                 labels_cfg=labels_cfg,
@@ -132,7 +131,7 @@ class GithubSync(Stats):
             }
         )
 
-    async def get_mapped_branches(self, series: Series) -> list[str]:
+    async def get_mapped_branches(self, series: Series) -> List[str]:
         for tag in self.tag_to_branch_mapping:
             if tag in await series.all_tags():
                 mapped_branches = self.tag_to_branch_mapping[tag]
@@ -171,7 +170,7 @@ class GithubSync(Stats):
 
     async def checkout_and_patch_safe(
         self, worker, branch_name: str, series_to_apply: Series
-    ) -> PullRequest | None:
+    ) -> Optional[PullRequest]:
         try:
             self.increment_counter("all_known_subjects")
             pr = await worker.checkout_and_patch(branch_name, series_to_apply)

--- a/kernel_patches_daemon/patchwork.py
+++ b/kernel_patches_daemon/patchwork.py
@@ -11,10 +11,9 @@ import datetime
 import json
 import logging
 import re
-from collections.abc import Sequence
 from functools import update_wrapper
 from types import SimpleNamespace
-from typing import Any, AnyStr, Dict, Final, List, Optional, Set, Tuple
+from typing import Any, AnyStr, Dict, Final, List, Optional, Sequence, Set, Tuple
 from urllib.parse import urljoin
 
 import aiohttp
@@ -33,7 +32,7 @@ from pyre_extensions import none_throws
 DEFAULT_HTTP_RETRIES = 3
 
 # when we want to push this patch through CI
-RELEVANT_STATES: dict[str, int] = {
+RELEVANT_STATES: Dict[str, int] = {
     "new": 1,
     "under-review": 2,
     "rfc": 5,
@@ -46,7 +45,7 @@ RFC_TAG: str = "RFC"
 TTL = {"changes-requested": 3600, "rfc": 3600}
 
 # when we are not interested in this patch anymore
-IRRELEVANT_STATES: dict[str, int] = {
+IRRELEVANT_STATES: Dict[str, int] = {
     "rejected": 4,
     "accepted": 3,
     "not-applicable": 6,
@@ -57,11 +56,11 @@ IRRELEVANT_STATES: dict[str, int] = {
     "handled-elsewhere": 17,
 }
 
-PW_CHECK_PENDING_STATES: dict[Status, str] = {
+PW_CHECK_PENDING_STATES: Dict[Status, str] = {
     Status.PENDING: "pending",
 }
 
-PW_CHECK_CONCLUSIVE_STATES: dict[Status, str] = {
+PW_CHECK_CONCLUSIVE_STATES: Dict[Status, str] = {
     Status.SUCCESS: "success",
     Status.SKIPPED: "success",
     Status.FAILURE: "fail",
@@ -69,7 +68,7 @@ PW_CHECK_CONCLUSIVE_STATES: dict[Status, str] = {
 }
 
 
-PW_CHECK_STATES: dict[Status, str] = {
+PW_CHECK_STATES: Dict[Status, str] = {
     **PW_CHECK_PENDING_STATES,
     **PW_CHECK_CONCLUSIVE_STATES,
 }
@@ -106,8 +105,8 @@ class TraceContext(SimpleNamespace):
     by using the handlers `on_request_start` and `on_request_end` respectively.
     """
 
-    start: float | None = None
-    end: float | None = None
+    start: Optional[float] = None
+    end: Optional[float] = None
 
     def elapsed(self) -> float:
         return none_throws(self.end) - none_throws(self.start)
@@ -208,7 +207,7 @@ def time_since_secs(date: str) -> float:
     return duration.total_seconds()
 
 
-def parse_tags(input: str) -> set[str]:
+def parse_tags(input: str) -> Set[str]:
     # "[tag1 ,tag2]title" -> "tag1,tags" -> ["tag1", "tag2"]
     try:
         parsed_tags = none_throws(re.match(TAG_REGEXP, input)).group("tags").split(",")
@@ -290,7 +289,7 @@ class Subject:
         self.subject = subject
 
     @property
-    async def branch(self) -> str | None:
+    async def branch(self) -> Optional[str]:
         relevant_series = await self.relevant_series
         if len(relevant_series) == 0:
             return None
@@ -305,7 +304,7 @@ class Subject:
 
     @property
     @cached(cache=TTLCache(maxsize=1, ttl=600))
-    async def relevant_series(self) -> list["Series"]:
+    async def relevant_series(self) -> List["Series"]:
         """
         cache and return sorted list of relevant series
         where first element is first known version of same subject
@@ -338,7 +337,7 @@ class Subject:
 
 
 class Series:
-    def __init__(self, pw_client: "Patchwork", data: dict) -> None:
+    def __init__(self, pw_client: "Patchwork", data: Dict) -> None:
         self.pw_client = pw_client
         self.data = data
         self._patch_blob = None
@@ -375,7 +374,7 @@ class Series:
                 f"Failed to parse subject from series name '{data['name']}'"
             ) from ex
 
-    def _is_patch_matching(self, patch: dict[str, Any]) -> bool:
+    def _is_patch_matching(self, patch: Dict[str, Any]) -> bool:
         for pattern in self.pw_client.search_patterns:
             for prop_name, expected_value in pattern.items():
                 if prop_name in PATCH_FILTERING_PROPERTIES:
@@ -395,7 +394,7 @@ class Series:
         return time_since_secs(self.date)
 
     @cached(cache=TTLCache(maxsize=1, ttl=600))
-    async def get_patches(self) -> tuple[dict]:
+    async def get_patches(self) -> Tuple[Dict]:
         """
         Returns patches preserving original order
         for the most recent relevant series
@@ -414,7 +413,7 @@ class Series:
         return False
 
     @cached(cache=TTLCache(maxsize=1, ttl=120))
-    async def all_tags(self) -> set[str]:
+    async def all_tags(self) -> Set[str]:
         """
         Tags fetched from series name, diffs and cover letter
         for most relevant series
@@ -432,14 +431,14 @@ class Series:
 
         return tags
 
-    async def visible_tags(self) -> set[str]:
+    async def visible_tags(self) -> Set[str]:
         return {
             f"V{self.version}",
             *[diff["state"] for diff in await self.get_patches()],
         }
 
     @cached(cache=TTLCache(maxsize=1, ttl=120))
-    async def patch_subjects(self) -> list[str]:
+    async def patch_subjects(self) -> List[str]:
         """
         Returns an ordered list of all patch subjects (tags removed)
         """
@@ -506,8 +505,8 @@ class Patchwork:
     def __init__(
         self,
         server: str,
-        search_patterns: list[dict[str, Any]],
-        auth_token: str | None = None,
+        search_patterns: List[Dict[str, Any]],
+        auth_token: Optional[str] = None,
         lookback_in_days: int = 7,
         api_version: str = "1.2",
         http_retries: int = DEFAULT_HTTP_RETRIES,
@@ -519,8 +518,8 @@ class Patchwork:
         self.search_patterns = search_patterns
         self.since = self.format_since(lookback_in_days)
         # member variable initializations
-        self.known_series: dict[int, Series] = {}
-        self.known_subjects: dict[str, Subject] = {}
+        self.known_series: Dict[int, Series] = {}
+        self.known_subjects: Dict[str, Subject] = {}
 
         # aiohttp's ClientSession needs to be initialized within an async function.
         # We will differ this initialization to a separate function and memoize it during first call.
@@ -558,7 +557,7 @@ class Patchwork:
         return lookback.strftime("%Y-%m-%dT%H:%M:%S")
 
     async def __get(
-        self, path: AnyStr, allow_redirects=True, **kwargs: dict
+        self, path: AnyStr, allow_redirects=True, **kwargs: Dict
     ) -> aiohttp.ClientResponse:
         http_session = await self.get_http_session()
         resp = await http_session.get(
@@ -569,13 +568,13 @@ class Patchwork:
         )
         return resp
 
-    async def __get_object_by_id(self, object_type: str, object_id: int) -> dict:
+    async def __get_object_by_id(self, object_type: str, object_id: int) -> Dict:
         resp = await self.__get(f"{object_type}/{object_id}/")
         return await resp.json()
 
     async def __get_objects_recursive(
-        self, object_type: str, params: dict | None = None
-    ) -> list[dict]:
+        self, object_type: str, params: Optional[Dict] = None
+    ) -> List[Dict]:
         items = []
         path = f"{object_type}/"
         if params is None:
@@ -593,7 +592,7 @@ class Patchwork:
             path = str(response.links["next"]["url"])
         return items
 
-    async def __post(self, path: AnyStr, data: dict) -> aiohttp.ClientResponse:
+    async def __post(self, path: AnyStr, data: Dict) -> aiohttp.ClientResponse:
         http_session = await self.get_http_session()
         resp = await http_session.post(
             # pyre-ignore
@@ -604,8 +603,8 @@ class Patchwork:
         return resp
 
     async def __try_post(
-        self, path: AnyStr, data: dict
-    ) -> aiohttp.ClientResponse | None:
+        self, path: AnyStr, data: Dict
+    ) -> Optional[aiohttp.ClientResponse]:
         if not self.auth_token:
             logger.debug(f"Patchwork POST {path}: read-only mode, request ignored")
             logger.debug(f"Patchwork POST data: {json_pprint(data)}")
@@ -621,7 +620,7 @@ class Patchwork:
         self,
         patch_id: int,
         context: str,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """
         Return dict of the latest check with matching context and patch_id if exists.
         Returns None if such check does not exist.
@@ -649,8 +648,8 @@ class Patchwork:
         return checks[0]
 
     async def post_check_for_patch_id(
-        self, patch_id: int, status: Status, check_data: dict[str, Any]
-    ) -> aiohttp.ClientResponse | None:
+        self, patch_id: int, status: Status, check_data: Dict[str, Any]
+    ) -> Optional[aiohttp.ClientResponse]:
         new_state = PW_CHECK_STATES.get(status, PW_CHECK_STATES[Status.PENDING])
         updated_check_data = {
             **check_data,
@@ -764,7 +763,7 @@ class Patchwork:
             # async function used to fetch latest series for each subject concurrently
             async def fetch_latest_series(
                 subject_name, subject_obj
-            ) -> tuple[str, Series, Series | None]:
+            ) -> Tuple[str, Series, Optional[Series]]:
                 return (subject_name, subject_obj, await subject_obj.latest_series)
 
             tasks = [fetch_latest_series(k, v) for k, v in subjects.items()]
@@ -796,10 +795,10 @@ class Patchwork:
         logger.info(f"Total relevant subjects found: {len(filtered_subjects)}")
         return filtered_subjects
 
-    async def get_patch_by_id(self, id: int) -> dict:
+    async def get_patch_by_id(self, id: int) -> Dict:
         return await self.__get_object_by_id("patches", id)
 
-    async def get_series(self, params: dict | None) -> list[Series]:
+    async def get_series(self, params: Optional[Dict]) -> List[Series]:
         return [
             Series(self, json)
             for json in await self.__get_objects_recursive("series", params=params)

--- a/kernel_patches_daemon/patchwork.py
+++ b/kernel_patches_daemon/patchwork.py
@@ -14,7 +14,7 @@ import re
 from collections.abc import Sequence
 from functools import update_wrapper
 from types import SimpleNamespace
-from typing import Any, AnyStr, Final, Optional
+from typing import Any, AnyStr, Dict, Final, List, Optional, Set, Tuple
 from urllib.parse import urljoin
 
 import aiohttp

--- a/kernel_patches_daemon/stats.py
+++ b/kernel_patches_daemon/stats.py
@@ -9,6 +9,7 @@
 import logging
 import time
 from collections.abc import Iterable
+from typing import Dict, Optional, Set, Union
 
 from opentelemetry import metrics
 from opentelemetry.util.types import Attributes

--- a/kernel_patches_daemon/stats.py
+++ b/kernel_patches_daemon/stats.py
@@ -8,15 +8,14 @@
 
 import logging
 import time
-from collections.abc import Iterable
-from typing import Dict, Optional, Set, Union
+from typing import Dict, Iterable, Optional, Set, Union
 
 from opentelemetry import metrics
 from opentelemetry.util.types import Attributes
 from pyre_extensions import none_throws
 
 STATS_KEY_BUG: str = "bug_occurence"
-DEFAULT_STATS: set[str] = {STATS_KEY_BUG}
+DEFAULT_STATS: Set[str] = {STATS_KEY_BUG}
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -24,7 +23,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 class Timer:
     def __init__(self) -> None:
-        self._start_time: int | None = None
+        self._start_time: Optional[int] = None
 
     def __enter__(self):
         self.start()
@@ -58,7 +57,7 @@ class Timer:
 
 class HistogramMetricTimer(Timer):
     def __init__(
-        self, metric: metrics.Histogram, attributes: Attributes | None = None
+        self, metric: metrics.Histogram, attributes: Optional[Attributes] = None
     ) -> None:
         self.metric: metrics.Histogram = metric
         self.attributes = attributes
@@ -71,8 +70,8 @@ class HistogramMetricTimer(Timer):
 
 class Stats:
     def __init__(self, counters: Iterable[str]) -> None:
-        self.counters: set[str] = set(counters)
-        self.stats: dict = {}
+        self.counters: Set[str] = set(counters)
+        self.stats: Dict = {}
         self.drop_counters()
 
     def drop_counters(self) -> None:
@@ -86,7 +85,7 @@ class Stats:
             self.stats[STATS_KEY_BUG] += 1
             logger.error(f"Failed to add {increment} increment to '{key}' stat")
 
-    def set_counter(self, key: str, value: int | float) -> None:
+    def set_counter(self, key: str, value: Union[int, float]) -> None:
         try:
             self.stats[key] = value
         except Exception:

--- a/kernel_patches_daemon/status.py
+++ b/kernel_patches_daemon/status.py
@@ -6,9 +6,8 @@
 
 # pyre-unsafe
 
-from collections.abc import Iterable
 from enum import Enum
-from typing import Optional
+from typing import Iterable, Optional
 
 
 class Status(Enum):
@@ -19,7 +18,7 @@ class Status(Enum):
     CONFLICT = "conflict"
 
 
-def gh_conclusion_to_status(gh_conclusion: str | None) -> Status:
+def gh_conclusion_to_status(gh_conclusion: Optional[str]) -> Status:
     """Translate a GitHub conclusion to our `Status` enum."""
     # GitHub reports pending jobs with a `None` conclusion.
     if gh_conclusion is None:

--- a/kernel_patches_daemon/status.py
+++ b/kernel_patches_daemon/status.py
@@ -8,6 +8,7 @@
 
 from collections.abc import Iterable
 from enum import Enum
+from typing import Optional
 
 
 class Status(Enum):

--- a/tests/common/patchwork_mock.py
+++ b/tests/common/patchwork_mock.py
@@ -43,7 +43,7 @@ def get_default_pw_client() -> PatchworkMock:
     )
 
 
-def init_pw_responses(m: aioresponses, data: dict[str, Any]) -> None:
+def init_pw_responses(m: aioresponses, data: Dict[str, Any]) -> None:
     """
     Setup an aioresponses mock to return patchwork answers.
 
@@ -71,7 +71,7 @@ def init_pw_responses(m: aioresponses, data: dict[str, Any]) -> None:
     m.get(re.compile(r"^.*$"), status=200, body=b"[]")
 
 
-def get_dict_key(d: dict[str, Any], idx: int = 0) -> str:
+def get_dict_key(d: Dict[str, Any], idx: int = 0) -> str:
     """
     Given a dictionary, get a list of keys and return the one a `idx`.
     """
@@ -82,7 +82,7 @@ FOO_SERIES_FIRST = 2
 FOO_SERIES_LAST = 10
 
 DEFAULT_FREEZE_DATE = "2010-07-23T00:00:00"
-DEFAULT_TEST_RESPONSES: dict[str, Any] = {
+DEFAULT_TEST_RESPONSES: Dict[str, Any] = {
     "https://127.0.0.1/api/1.1/series/?q=foo": [
         # Does not match the subject name
         {

--- a/tests/test_branch_worker.py
+++ b/tests/test_branch_worker.py
@@ -65,7 +65,7 @@ TEST_CI_REPO_URL = f"https://user:pass@127.0.0.1/ci-org/{TEST_CI_REPO}"
 TEST_CI_BRANCH = "test_ci_branch"
 TEST_BASE_DIRECTORY = "/repos"
 TEST_BRANCH = "test-branch"
-TEST_CONFIG: dict[str, Any] = {
+TEST_CONFIG: Dict[str, Any] = {
     "version": 2,
     "project": "test",
     "pw_url": "pw",
@@ -88,7 +88,7 @@ TEST_LABELS_CFG = {
     "RFC": "f2e318",
     "new": "c2e0c6",
 }
-SERIES_DATA: dict[str, Any] = {
+SERIES_DATA: Dict[str, Any] = {
     "id": 0,
     "name": "foo",
     "date": "2010-07-20T01:00:00",
@@ -179,7 +179,7 @@ class TestBranchWorker(unittest.IsolatedAsyncioTestCase):
         @dataclass
         class TestCase:
             name: str
-            prs: list[PR]
+            prs: List[PR]
             added_pr_delta: int = 0
             relevant_prs_delta: int = 0
 
@@ -555,7 +555,7 @@ class TestBranchWorker(unittest.IsolatedAsyncioTestCase):
         @dataclass
         class TestCase:
             name: str
-            closed_prs: list[Munch]
+            closed_prs: List[Munch]
             branch: str
             return_pr: Munch
 
@@ -913,7 +913,7 @@ class TestGitSeriesAlreadyApplied(unittest.IsolatedAsyncioTestCase):
         # Patchwork client
         self._pw = get_default_pw_client()
 
-    async def _get_series(self, m: aioresponses, summaries: list[str]) -> Series:
+    async def _get_series(self, m: aioresponses, summaries: List[str]) -> Series:
         """
         Given a list of commit summaries, return a `Series` that
         contains such commits.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ from kernel_patches_daemon.config import (
 )
 
 
-def read_fixture(filepath: str) -> dict[str, str | int | bool | dict]:
+def read_fixture(filepath: str) -> Dict[str, Union[str, int, bool, Dict]]:
     with open(os.path.join(os.path.dirname(__file__), filepath)) as f:
         return json.load(f)
 
@@ -43,7 +43,7 @@ class TestConfig(unittest.TestCase):
         @dataclass
         class TestCase:
             name: str
-            tag_to_branch_mapping: dict[str, list[str]]
+            tag_to_branch_mapping: Dict[str, List[str]]
 
         test_cases = [
             TestCase(
@@ -85,7 +85,7 @@ class TestConfig(unittest.TestCase):
         @dataclass
         class TestCase:
             name: str
-            tag_to_branch_mapping: dict[str, list[str]]
+            tag_to_branch_mapping: Dict[str, List[str]]
 
         test_cases = [
             TestCase(

--- a/tests/test_github_connector.py
+++ b/tests/test_github_connector.py
@@ -32,7 +32,7 @@ from kernel_patches_daemon.github_connector import (
 # unfortunately, this has the side effect of not freezing the time for the github
 # package... Here we are popping anything that could get in the way from the dfault list
 # https://github.com/spulec/freezegun/issues/484
-default_ignore_list: list[str] = [
+default_ignore_list: List[str] = [
     x for x in freezegun.config.DEFAULT_IGNORE_LIST if not "github".startswith(x)
 ]
 # pyre-fixme[16]: Module freezegun has no attribute configure
@@ -179,8 +179,8 @@ class TestGithubConnector(unittest.TestCase):
         @dataclass
         class TestCase:
             name: str
-            oauth_token: str | None = "some oauth token"
-            app_auth: AppAuthentication | None = AppAuthentication(
+            oauth_token: Optional[str] = "some oauth token"
+            app_auth: Optional[AppAuthentication] = AppAuthentication(
                 TEST_APP_ID, TEST_PRIV_KEY, TEST_INSTALLATION_ID
             )
             exception_expected: bool = True

--- a/tests/test_github_connector.py
+++ b/tests/test_github_connector.py
@@ -9,7 +9,7 @@
 import datetime
 import unittest
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, List, Optional
 from unittest.mock import MagicMock, patch
 
 import freezegun

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -17,7 +17,7 @@ from kernel_patches_daemon.config import KPDConfig
 from kernel_patches_daemon.github_sync import GithubSync
 
 TEST_BRANCH = "test-branch"
-TEST_CONFIG: dict[str, Any] = {
+TEST_CONFIG: Dict[str, Any] = {
     "version": 3,
     "patchwork": {
         "project": "test",
@@ -41,7 +41,7 @@ TEST_CONFIG: dict[str, Any] = {
 
 class GithubSyncMock(GithubSync):
     def __init__(
-        self, kpd_config: KPDConfig | None = None, *args: Any, **kwargs: Any
+        self, kpd_config: Optional[KPDConfig] = None, *args: Any, **kwargs: Any
     ) -> None:
         if kpd_config is None:
             kpd_config = KPDConfig.from_json(TEST_CONFIG)
@@ -72,7 +72,7 @@ class TestGihubSync(unittest.IsolatedAsyncioTestCase):
         class TestCase:
             name: str
             prefix: str
-            base_dir: str | None = None
+            base_dir: Optional[str] = None
 
         test_cases = [
             TestCase(

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -9,7 +9,7 @@
 import copy
 import unittest
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from kernel_patches_daemon.branch_worker import NewPRWithNoChangeException

--- a/tests/test_patchwork.py
+++ b/tests/test_patchwork.py
@@ -80,17 +80,17 @@ class TestPatchwork(PatchworkTestCase):
         @dataclass
         class Response:
             body: bytes
-            headers: dict[str, str]
+            headers: Dict[str, str]
             url: str = "https://127.0.0.1/api/1.1/projects/"
             status_code: int = 200
 
         @dataclass
         class TestCase:
             name: str
-            pages: list[Response]
-            expected: list[Any]
+            pages: List[Response]
+            expected: List[Any]
             get_calls: int
-            filters: dict[str, str] | MultiDict | None = None
+            filters: Optional[Union[Dict[str, str], MultiDict]] = None
 
         test_cases = [
             TestCase(
@@ -231,7 +231,7 @@ class TestPatchwork(PatchworkTestCase):
         class TestCase:
             name: str
             title: str
-            expected: set[str]
+            expected: Set[str]
 
         test_cases = [
             TestCase(

--- a/tests/test_patchwork.py
+++ b/tests/test_patchwork.py
@@ -11,7 +11,7 @@ import datetime
 import re
 import unittest
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict, List, Optional, Set, Union
 
 from aioresponses import aioresponses
 


### PR DESCRIPTION
Those 2 codemod assumed python 3.10+ and currently break upstream KPD. 3.9 is still what is shipped on CentOS 9, probably good to keep around.